### PR TITLE
Fix "currentActiveItem" is read-only

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -97,7 +97,7 @@ export default class Carousel {
    * @return {void}
    */
   _initOrder() {
-    const currentActiveItem = this.element.querySelector('.carousel-item.is-active');
+    let currentActiveItem = this.element.querySelector('.carousel-item.is-active');
     if (!currentActiveItem) {
       this.items[0].classList.add('is-active');
       currentActiveItem = this.items[0];


### PR DESCRIPTION
When attempting to compile this library with babel, the following error occurs:

```bash
{ SyntaxError: /Users/danieldoyle/Projects/Indigo White/Drupal/backend/sites/all/themes/indigo_white_base/node_modules/bulma-carousel/dist/bulma-carousel.js: "currentActiveItem" is read-only
  104 |     if (!currentActiveItem) {
  105 |       this.items[0].classList.add('is-active');
> 106 |       currentActiveItem = this.items[0];
      |       ^
  107 |     }
  108 |     const currentActiveItemPos = this.items.indexOf(currentActiveItem);
```

This is due to reassigning a `const` within an if statement. This PR defines `currentActiveItem` as `let`