### PR TITLE
Angular compatibility fixes

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -9,6 +9,7 @@ export default class Carousel {
         : selector;
     // An invalid selector or non-DOM node has been provided.
     if (!this.element) {
+      console.log(selector);
       throw new Error('An invalid selector or non-DOM node has been provided.');
     }
 
@@ -124,10 +125,12 @@ export default class Carousel {
     const length = this.items.length;
 
     if (currentActiveItemPos) {
-      this.items.push(this.items.splice(0, currentActiveItemPos));
+      //  this.items.push(this.items.splice(0, currentActiveItemPos));
+      this.items.push(this.items.shift());
     } else {
       this.items.unshift(this.items.pop());
     }
+
     this._setOrder();
   }
 
@@ -138,7 +141,7 @@ export default class Carousel {
   _setOrder() {
     this.items.forEach((item, index) => {
       if (index !== 1) {
-        item.style['z-index'] = '0';
+        item.style['z-index'] = '1';
       } else {
         item.style['z-index'] = '1';
       }
@@ -232,7 +235,7 @@ export default class Carousel {
         this.element.classList.remove('is-reversing');
       }
 
-      if (this.items.length >= 1) {
+      if (this.items.length > 1) {
         newActiveItem = this.items[1];
       } else {
         newActiveItem = this.items[0];
@@ -268,8 +271,10 @@ export default class Carousel {
    */
   static attach() {
     var carousels = document.querySelectorAll('.carousel, .hero-carousel');
-    [].forEach.call(carousels, function(carousel) {
-      new Carousel(carousel);
+    carousels.forEach(el => {
+      setTimeout(() => {
+        new Carousel(el);
+      }, 100);
     });
   }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -141,7 +141,7 @@ export default class Carousel {
   _setOrder() {
     this.items.forEach((item, index) => {
       if (index !== 1) {
-        item.style['z-index'] = '1';
+        item.style['z-index'] = '0';
       } else {
         item.style['z-index'] = '1';
       }

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,9 +1,12 @@
 export default class Carousel {
   constructor(selector) {
     // Determine click event depending on if we are on Touch device or not
-    this._clickEvent = ('ontouchstart' in window) ? 'touchstart' : 'click';
+    this._clickEvent = 'ontouchstart' in window ? 'touchstart' : 'click';
 
-    this.element = typeof selector === 'string' ? document.querySelector(selector) : selector;
+    this.element =
+      typeof selector === 'string'
+        ? document.querySelector(selector)
+        : selector;
     // An invalid selector or non-DOM node has been provided.
     if (!this.element) {
       throw new Error('An invalid selector or non-DOM node has been provided.');
@@ -19,7 +22,7 @@ export default class Carousel {
    */
   init() {
     this.items = Array.from(this.element.querySelectorAll('.carousel-item'));
-    this.items.forEach((item) => {
+    this.items.forEach(item => {
       let img = item.querySelector('img');
       img.setAttribute('draggable', false);
     });
@@ -28,7 +31,9 @@ export default class Carousel {
     this.previousControl = this.element.querySelector('.carousel-nav-left');
     this.nextControl = this.element.querySelector('.carousel-nav-right');
     if (this.items.length <= 1) {
-      const carouselContainer = this.element.querySelector('.carousel-container');
+      const carouselContainer = this.element.querySelector(
+        '.carousel-container'
+      );
       if (carouselContainer) {
         carouselContainer.style.left = '0';
       }
@@ -43,7 +48,10 @@ export default class Carousel {
     this._bindEvents();
     this._initOrder();
 
-    if (this.element.dataset.autoplay && this.element.dataset.autoplay == 'true') {
+    if (
+      this.element.dataset.autoplay &&
+      this.element.dataset.autoplay == 'true'
+    ) {
       this._autoPlay(this.element.dataset.delay || 5000);
     }
   }
@@ -55,38 +63,46 @@ export default class Carousel {
    */
   _bindEvents() {
     if (this.previousControl) {
-      this.previousControl.addEventListener(this._clickEvent, (e) => {
-        e.preventDefault();
-        this._slide('previous');
-        if (this._autoPlayInterval) {
-          clearInterval(this._autoPlayInterval);
-          this._autoPlay(this.element.dataset.delay || 5000);
-        }
-      }, false);
+      this.previousControl.addEventListener(
+        this._clickEvent,
+        e => {
+          e.preventDefault();
+          this._slide('previous');
+          if (this._autoPlayInterval) {
+            clearInterval(this._autoPlayInterval);
+            this._autoPlay(this.element.dataset.delay || 5000);
+          }
+        },
+        false
+      );
     }
     if (this.nextControl) {
-      this.nextControl.addEventListener(this._clickEvent, (e) => {
-        e.preventDefault();
-        this._slide('next');
-        if (this._autoPlayInterval) {
-          clearInterval(this._autoPlayInterval);
-          this._autoPlay(this.element.dataset.delay || 5000);
-        }
-      }, false);
+      this.nextControl.addEventListener(
+        this._clickEvent,
+        e => {
+          e.preventDefault();
+          this._slide('next');
+          if (this._autoPlayInterval) {
+            clearInterval(this._autoPlayInterval);
+            this._autoPlay(this.element.dataset.delay || 5000);
+          }
+        },
+        false
+      );
     }
 
     // Bind swipe events
-    this.element.addEventListener('touchstart', (e) => {
+    this.element.addEventListener('touchstart', e => {
       this._swipeStart(e);
     });
-    this.element.addEventListener('mousedown', (e) => {
+    this.element.addEventListener('mousedown', e => {
       this._swipeStart(e);
     });
 
-    this.element.addEventListener('touchend', (e) => {
+    this.element.addEventListener('touchend', e => {
       this._swipeEnd(e);
     });
-    this.element.addEventListener('mouseup', (e) => {
+    this.element.addEventListener('mouseup', e => {
       this._swipeEnd(e);
     });
   }
@@ -97,7 +113,9 @@ export default class Carousel {
    * @return {void}
    */
   _initOrder() {
-    let currentActiveItem = this.element.querySelector('.carousel-item.is-active');
+    let currentActiveItem = this.element.querySelector(
+      '.carousel-item.is-active'
+    );
     if (!currentActiveItem) {
       this.items[0].classList.add('is-active');
       currentActiveItem = this.items[0];
@@ -144,7 +162,7 @@ export default class Carousel {
         x: e.clientX,
         y: e.clientY
       }
-    }
+    };
   }
 
   /**
@@ -157,7 +175,7 @@ export default class Carousel {
     this._touch.end = {
       x: e.clientX,
       y: e.clientY
-    }
+    };
 
     this._handleGesture();
   }
@@ -169,8 +187,12 @@ export default class Carousel {
    */
   _handleGesture() {
     const ratio = {
-      horizontal: (this._touch.end.x - this._touch.start.x) / parseInt(this.computedStyle.getPropertyValue('width')),
-      vertical: (this._touch.end.y - this._touch.start.y) / parseInt(this.computedStyle.getPropertyValue('height'))
+      horizontal:
+        (this._touch.end.x - this._touch.start.x) /
+        parseInt(this.computedStyle.getPropertyValue('width')),
+      vertical:
+        (this._touch.end.y - this._touch.start.y) /
+        parseInt(this.computedStyle.getPropertyValue('height'))
     };
 
     if (ratio.horizontal > ratio.vertical && ratio.horizontal > 0.25) {
@@ -190,7 +212,9 @@ export default class Carousel {
    */
   _slide(direction = 'next') {
     if (this.items.length) {
-      const currentActiveItem = this.element.querySelector('.carousel-item.is-active');
+      const currentActiveItem = this.element.querySelector(
+        '.carousel-item.is-active'
+      );
       let newActiveItem;
 
       currentActiveItem.classList.remove('is-active');
@@ -236,16 +260,16 @@ export default class Carousel {
       this._slide('next');
     }, delay);
   }
-}
 
-/**
- * Initiate all DOM element containing carousel class
- * @method
- * @return {[type]} [description]
- */
-document.addEventListener('DOMContentLoaded', function() {
-  var carousels = document.querySelectorAll('.carousel, .hero-carousel');
-  [].forEach.call(carousels, function(carousel) {
-    new Carousel(carousel);
-  });
-});
+  /**
+   * Initiate all DOM element containing carousel class
+   * @method
+   * @return {[type]} [description]
+   */
+  static attach() {
+    var carousels = document.querySelectorAll('.carousel, .hero-carousel');
+    [].forEach.call(carousels, function(carousel) {
+      new Carousel(carousel);
+    });
+  }
+}


### PR DESCRIPTION
Only tested with angular, but this should ***probably*** fix integration with other frameworks like vue and react as well.  One big caveat to this is I removed the on dom ready auto-attachment.  Frameworks like angular and react (and I think vue?) have their own shadow dom that is a separate ready event.  Adding this method lets you attach when you're framework of choice is ready.

The downside is if you're not using a framework like these, you'll have to manually call Carousel.attach()  after loading the script on the page.

Also sorry for all the formatting changes, my code editor reformats automatically and I didn't even think about it before I worked through the changes.

**Main Changes:**

- Added static attach method to attach the carousel instead of just auto-attaching at run time.  This is allows angular to re-attach if it dynamically changes the carousel items.

- Added 100ms buffer to the element attachment (in the static attach method).  For some reason in angular, things were just flying too fast, and it would try to attach before angular was finished with the dom.

- Line 221 had this:
```javascript
if (this.items.length >= 1) {
```
which I'm pretty sure was a bug, if items has 1 element, it matches that statement, but then you're setting to items[1] which would fail and cause issues when applying classes to null items.



should definitely fix #27 , potentially fixes or related to #30