### PR TITLE
Add an option to stop autoplay when a user interacts with the carousel.

### DIFF
--- a/src/js/defaultOptions.js
+++ b/src/js/defaultOptions.js
@@ -1,6 +1,7 @@
 const defaultOptions = {
   size: 1,
   autoplay: false,
+  stopautoplayoninteraction: false, // stop autoplay if a user interacts with the controls
   delay: 5000,
   threshold: 50, //required min distance traveled to be considered swipe
   restraint: 100, // maximum distance allowed at the same time in perpendicular direction

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -52,6 +52,9 @@ export default class bulmaCarousel extends EventEmitter {
     if (this.element.classList.contains('carousel-animate-fade')) {
       this.options.size = 1;
     }
+    if (this.element.dataset.stopautoplayoninteraction) {
+      this.options.stopautoplayoninteraction = this.element.dataset.stopautoplayoninteraction;
+    }
 
     this.forceHiddenNavigation = false;
 
@@ -166,7 +169,9 @@ export default class bulmaCarousel extends EventEmitter {
           }
           if (this._autoPlayInterval) {
             clearInterval(this._autoPlayInterval);
-            this._autoPlay(this.optionsdelay);
+            if (!this.options.stopautoplayoninteraction) {
+              this._autoPlay(this.options.delay);
+            }
           }
           this._slide('previous');
         }, supportsPassive ? { passive: true } : false);
@@ -181,7 +186,9 @@ export default class bulmaCarousel extends EventEmitter {
           }
           if (this._autoPlayInterval) {
             clearInterval(this._autoPlayInterval);
-            this._autoPlay(this.options.delay);
+            if (!this.options.stopautoplayoninteraction) {
+              this._autoPlay(this.options.delay);
+            }
           }
           this._slide('next');
         }, supportsPassive ? { passive: true } : false);
@@ -365,6 +372,9 @@ export default class bulmaCarousel extends EventEmitter {
     if (this.items.length) {
       this.oldItemNode = this.currentItem.node;
       this.emit(BULMA_CAROUSEL_EVENTS.slideBefore, this.currentItem);
+      if(this.options.stopautoplayoninteraction) {
+        clearInterval(this._autoPlayInterval);
+      }
       // initialize direction to change order
       if (direction === 'previous') {
         this.currentItem.node = this._previous(this.currentItem.node);


### PR DESCRIPTION
Autoplay is great, but once a user interacts with the carousel, they're indicating that they want to look longer at something so we probably shouldn't continue to scroll for them.

This PR adds an option for this behavior and the default maintains the current functionality.

Also, fixes a minor bug on index.js line 173 `this._autoPlay(this.optionsdelay); ` probably should have been `this._autoPlay(this.options.delay);`