### PR TITLE
Always update slider dimensions on resize

### DIFF
--- a/src/js/components/breakpoint.js
+++ b/src/js/components/breakpoint.js
@@ -84,6 +84,8 @@ export default class Breakpoints {
 		if (newBreakPoint.slidesToShow !== this._currentBreakpoint.slidesToShow) {
 			this._currentBreakpoint = newBreakPoint;
 			this.apply();
+		} else {
+			this.slider._setDimensions();
 		}
 	}
 }


### PR DESCRIPTION
I have an issue where a single slider item is not resizing when the browser window is resized. This is because in the `[onResize]` function, it checks whether the amount of slides has changed. Since this is still 1, it does nothing.

I _think_ the only thing that needs to be done, is update the dimensions of the slider. For me it does solve the issue.

**Bug reproduction scenario:**
-  Add carousel with 1 `slidesToShow` (or don't pass anything since I believe that's the default
-  Open page
-  Change browser window size
-  Observe

**Expected behaviour:**
The slide item should resize according to the size of the window.

**Actual behaviour:**
The slide item remains the same size and is only updated after a refresh of the  page.