### PR TITLE
Fix cloneNode error when infinite

### DIFF
--- a/src/js/components/infinite.js
+++ b/src/js/components/infinite.js
@@ -14,7 +14,7 @@ export default class Infinite {
 			let frontClones = [];
 			let slideIndex = 0;
 			for (let i = this.slider.state.length; i > (this.slider.state.length - 1 - this._infiniteCount); i -= 1) {
-				slideIndex = i - 1;
+				slideIndex = (this.slider.state.length * Math.floor(this._infiniteCount / this.slider.state.length) + i - 1) % this.slider.state.length;
 				frontClones.unshift(this._cloneSlide(this.slider.slides[slideIndex], slideIndex - this.slider.state.length));
 			}
 


### PR DESCRIPTION
## WHY
I encountered `cloneNode` error while using bulma-carousel with `infinite` option true.

```
Uncaught TypeError: Cannot read property 'cloneNode' of undefined
```

As mentioned in the issue https://github.com/Wikiki/bulma-carousel/issues/89, the error occurs when i set `infinite: true` and `slidesToShow` value is greater or equal to the length of the `.carousel-item` elements because the index goes to negative.

## WHAT
Fix the index calculation to get always get a positive index (within the length).